### PR TITLE
feat(timetable): By default, select the day with upcoming lessons instead of the current day

### DIFF
--- a/lib/pages/timetable/timetable_page.dart
+++ b/lib/pages/timetable/timetable_page.dart
@@ -39,13 +39,12 @@ class _TimetablePageState extends State<TimetablePage> with TickerProviderStateM
   late TabController _tabController;
   late Widget empty;
 
-  bool _sameDate(DateTime a, DateTime b) => (a.year == b.year && a.month == b.month && a.day == b.day);
   int _getDayIndex(DateTime date) {
     int index = 0;
     if (_controller.days == null || _controller.days?.length == 0) return index;
 
-    // find the first day with the current date
-    index = _controller.days?.indexOf(_controller.days!.firstWhere((day) => _sameDate(day.first.date, date), orElse: () => [])) ?? 0;
+    // find the first day with upcoming lessons
+    index = _controller.days!.indexWhere((day) => day.last.end.isAfter(date));
     if (index == -1) index = 0; // fallback
 
     return index;


### PR DESCRIPTION
**Why?**
For example, if you open the app at 5 pm, it's highly likely that you don't want to see what lessons you have had, but want to see what lessons you'll have the next day.